### PR TITLE
feat: Add Allay Loom and Cartography Table screen handlers

### DIFF
--- a/src/main/generated/assets/portableallays/lang/en_us.json
+++ b/src/main/generated/assets/portableallays/lang/en_us.json
@@ -3,6 +3,8 @@
   "container.portableallays.enderchest": "Ender Chest",
   "container.portableallays.stonecutter": "Stonecutter",
   "container.portableallays.upgrade": "Upgrade Gear",
+  "container.portableallays.heirloom": "Loom",
+  "container.portableallays.mappingmenu": "Cartography Table",
   "item.portableallays.allay": "Allay",
   "item.portableallays.allay_potion.effect.awkward": "Allay Awkward Potion",
   "item.portableallays.allay_potion.effect.fire_resistance": "Allay Potion of Fire Resistance",

--- a/src/main/generated/assets/portableallays/lang/en_us.json
+++ b/src/main/generated/assets/portableallays/lang/en_us.json
@@ -1,10 +1,11 @@
 {
   "container.portableallays.crafting": "Crafting",
   "container.portableallays.enderchest": "Ender Chest",
-  "container.portableallays.stonecutter": "Stonecutter",
-  "container.portableallays.upgrade": "Upgrade Gear",
+  "container.portableallays.furnace": "Furnace",
   "container.portableallays.heirloom": "Loom",
   "container.portableallays.mappingmenu": "Cartography Table",
+  "container.portableallays.stonecutter": "Stonecutter",
+  "container.portableallays.upgrade": "Upgrade Gear",
   "item.portableallays.allay": "Allay",
   "item.portableallays.allay_potion.effect.awkward": "Allay Awkward Potion",
   "item.portableallays.allay_potion.effect.fire_resistance": "Allay Potion of Fire Resistance",

--- a/src/main/generated/data/portableallays/tags/item/allay_valid_crafting_items.json
+++ b/src/main/generated/data/portableallays/tags/item/allay_valid_crafting_items.json
@@ -4,11 +4,12 @@
     "minecraft:stonecutter",
     "minecraft:ender_chest",
     "minecraft:smithing_table",
-    "minecraft:furnace"
+    "minecraft:furnace",
+    "minecraft:loom",
+    "minecraft:cartography_table",
     {
       "id": "#c:shulker_boxes",
       "required": false
     }
-    
   ]
 }

--- a/src/main/java/portableallays/datagen/ModEnglishLangProvider.java
+++ b/src/main/java/portableallays/datagen/ModEnglishLangProvider.java
@@ -37,6 +37,8 @@ public class ModEnglishLangProvider extends FabricLanguageProvider {
         translationBuilder.add(makeArbitrary("container", "enderchest"), "Ender Chest");
         translationBuilder.add(makeArbitrary("container", "upgrade"), "Upgrade Gear");
         translationBuilder.add(makeArbitrary("container", "furnace"), "Furnace");
+        translationBuilder.add(makeArbitrary("container", "heirloom"), "Loom");
+        translationBuilder.add(makeArbitrary("container", "mappingmenu"), "Cartography Table");
         HashSet<String> Visited = new HashSet<>();
         registryLookup.getOptionalWrapper(RegistryKeys.POTION).ifPresent((R) -> R.streamKeys().forEach((key) -> {
             ItemStack stack = new ItemStack(ModItems.ALLAY_POTION_ITEM);

--- a/src/main/java/portableallays/datagen/ModItemTagProvider.java
+++ b/src/main/java/portableallays/datagen/ModItemTagProvider.java
@@ -26,7 +26,9 @@ public class ModItemTagProvider extends FabricTagProvider.ItemTagProvider {
                         Items.STONECUTTER,
                         Items.ENDER_CHEST,
                         Items.SMITHING_TABLE,
-                        Items.FURNACE
+                        Items.FURNACE,
+                        Items.LOOM,
+                        Items.CARTOGRAPHY_TABLE
                 )
                 .addOptionalTag(
                         ModTags.SHULKER_BOXES

--- a/src/main/java/portableallays/mixin/ItemStackMixin.java
+++ b/src/main/java/portableallays/mixin/ItemStackMixin.java
@@ -1,0 +1,2 @@
+package portableallays.mixin;public class ItemStackMixin {
+}

--- a/src/main/java/portableallays/screenhandler/AllayCartographyTableScreenHandler.java
+++ b/src/main/java/portableallays/screenhandler/AllayCartographyTableScreenHandler.java
@@ -1,0 +1,48 @@
+package portableallays.screenhandler;
+
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.mob.PiglinBrain;
+import net.minecraft.entity.passive.AllayEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.CartographyTableScreenHandler;
+import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerContext;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
+
+public class AllayCartographyTableScreenHandler extends CartographyTableScreenHandler {
+    private static final Text CONTAINER_NAME = Text.translatable("container.portableallays.mappingmenu");
+    private final AllayEntity allay;
+    public AllayCartographyTableScreenHandler(int syncId, PlayerInventory playerInventory, ServerPlayerEntity player, AllayEntity allay) {
+        super(syncId, playerInventory, ScreenHandlerContext.create(allay.getWorld(), allay.getBlockPos()));
+        this.allay = allay;
+    }
+
+    @Override
+    public boolean canUse(PlayerEntity player) {
+        return allay.distanceTo(player) < player.getAttributes().getValue(EntityAttributes.PLAYER_BLOCK_INTERACTION_RANGE);
+    }
+
+    public static void open(ServerPlayerEntity player, AllayEntity allay) {
+        player.openHandledScreen(new NamedScreenHandlerFactory() {
+            @Override
+            public Text getDisplayName() {
+                return CONTAINER_NAME;
+            }
+
+            @Nullable
+            @Override
+            public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
+                if (!(player instanceof ServerPlayerEntity))
+                    return null;
+                player.incrementStat(Stats.INTERACT_WITH_CARTOGRAPHY_TABLE);
+                PiglinBrain.onGuardedBlockInteracted(player, true);
+                return new AllayCartographyTableScreenHandler(syncId, playerInventory, (ServerPlayerEntity) player, allay);
+            }
+        });
+    }
+}

--- a/src/main/java/portableallays/screenhandler/AllayLoomScreenHandler.java
+++ b/src/main/java/portableallays/screenhandler/AllayLoomScreenHandler.java
@@ -1,0 +1,48 @@
+package portableallays.screenhandler;
+
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.mob.PiglinBrain;
+import net.minecraft.entity.passive.AllayEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.LoomScreenHandler;
+import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerContext;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
+
+public class AllayLoomScreenHandler extends LoomScreenHandler {
+    private static final Text CONTAINER_NAME = Text.translatable("container.portableallays.heirloom");
+    private final AllayEntity allay;
+    public AllayLoomScreenHandler(int syncId, PlayerInventory playerInventory, ServerPlayerEntity player, AllayEntity allay) {
+        super(syncId, playerInventory, ScreenHandlerContext.create(allay.getWorld(), allay.getBlockPos()));
+        this.allay = allay;
+    }
+
+    @Override
+    public boolean canUse(PlayerEntity player) {
+        return allay.distanceTo(player) < player.getAttributes().getValue(EntityAttributes.PLAYER_BLOCK_INTERACTION_RANGE);
+    }
+
+    public static void open(ServerPlayerEntity player, AllayEntity allay) {
+        player.openHandledScreen(new NamedScreenHandlerFactory() {
+            @Override
+            public Text getDisplayName() {
+                return CONTAINER_NAME;
+            }
+
+            @Nullable
+            @Override
+            public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
+                if (!(player instanceof ServerPlayerEntity))
+                    return null;
+                player.incrementStat(Stats.INTERACT_WITH_LOOM);
+                PiglinBrain.onGuardedBlockInteracted(player, true);
+                return new AllayLoomScreenHandler(syncId, playerInventory, (ServerPlayerEntity) player, allay);
+            }
+        });
+    }
+}

--- a/src/main/java/portableallays/screenhandler/ModScreenHandlers.java
+++ b/src/main/java/portableallays/screenhandler/ModScreenHandlers.java
@@ -20,6 +20,9 @@ public class ModScreenHandlers {
             AllaySmithingScreenHandler.open(player, allay);
         if (craftingStack.isOf(Items.FURNACE))
             AllayFurnaceScreenHandler.open(player, allay);
-        
+        if (craftingStack.isOf(Items.LOOM))
+            AllayLoomScreenHandler.open(player, allay);
+        if (craftingStack.isOf(Items.CARTOGRAPHY_TABLE))
+            AllayCartographyTableScreenHandler.open(player, allay);
     }
 }


### PR DESCRIPTION
The code changes include the addition of two new screen handlers: `AllayLoomScreenHandler` and `AllayCartographyTableScreenHandler`. These screen handlers are used for interacting with the Allay entity in the game.